### PR TITLE
Fix home page class names

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,11 +8,11 @@ export default function Home() {
     <main
       className={`flex min-h-screen flex-col items-center justify-between p-24 ${inter.className}`}
     >
-      <div className="z-10 flex flex-col max-w-5xl w-full items-center align-items-start font-mono text-sm">
+      <div className="z-10 flex flex-col max-w-5xl w-full items-center items-start font-mono text-sm">
 	  <p>Caspy</p>
       </div>
       <div>
-	  <p classname="text-xl">The Spatial Video Repository</p>
+          <p className="text-xl">The Spatial Video Repository</p>
 	  <p>Store and search the most intuitive medium.</p> 
       </div>
       <div>


### PR DESCRIPTION
## Summary
- fix wrong class names in `src/pages/index.js`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb5e9cc4883299a8e84189b09a91c